### PR TITLE
商品購入機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ gem 'pry-rails'
 
 gem 'mini_magick'
 gem 'image_processing', '~> 1.2'
+gem 'payjp'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,8 @@ GEM
       responders
       warden (~> 1.2.3)
     diff-lcs (1.5.0)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.11.0)
     factory_bot (6.2.1)
       activesupport (>= 5.0.0)
@@ -99,6 +101,9 @@ GEM
     ffi (1.15.5)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    http-accept (1.7.0)
+    http-cookie (1.0.5)
+      domain_name (~> 0.5)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.2)
@@ -123,6 +128,9 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_magick (4.12.0)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
@@ -138,6 +146,7 @@ GEM
       timeout
     net-smtp (0.3.3)
       net-protocol
+    netrc (0.11.0)
     nio4r (2.5.8)
     nokogiri (1.13.10)
       mini_portile2 (~> 2.8.0)
@@ -148,6 +157,8 @@ GEM
     parallel (1.22.1)
     parser (3.1.3.0)
       ast (~> 2.4.1)
+    payjp (0.0.10)
+      rest-client (~> 2.0)
     pg (1.4.5)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -197,6 +208,11 @@ GEM
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
+    rest-client (2.1.0)
+      http-accept (>= 1.7.0, < 2.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rexml (3.2.5)
     rspec-core (3.12.0)
       rspec-support (~> 3.12.0)
@@ -267,6 +283,9 @@ GEM
     turbolinks-source (5.2.0)
     tzinfo (1.2.10)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.8.2)
     unicode-display_width (2.3.0)
     warden (1.2.9)
       rack (>= 2.0.9)
@@ -307,6 +326,7 @@ DEPENDENCIES
   listen (>= 3.0.5, < 3.2)
   mini_magick
   mysql2 (>= 0.4.4)
+  payjp
   pg
   pry-rails
   puma (~> 3.11)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 | city          | string     | null: false                    |
 | street_number | string     | null: false                    |
 | building      | string     |                                |
-| phone_number  | string     | null: false                    |
+| phone_number  | integer    | null: false                    |
 | order         | references | null: false, foreign_key: true |
 
  

--- a/app/assets/stylesheets/addresses.scss
+++ b/app/assets/stylesheets/addresses.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the addresses controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/orders.scss
+++ b/app/assets/stylesheets/orders.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the orders controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/addresses_controller.rb
+++ b/app/controllers/addresses_controller.rb
@@ -1,0 +1,2 @@
+class AddressesController < ApplicationController
+end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,9 +23,7 @@ class ItemsController < ApplicationController
   end
 
   def edit
-     if current_user.id != @item.user_id
-        redirect_to action: :index
-     elsif @item.order.present?
+     if current_user.id != @item.user_id || @item.order.present?
       redirect_to root_path
      end
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -40,7 +40,7 @@ class ItemsController < ApplicationController
 
   def destroy
     if current_user.id == @item.user_id
-      item.destroy
+      @item.destroy
     end
       redirect_to root_path
   end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,6 +25,8 @@ class ItemsController < ApplicationController
   def edit
      if current_user.id != @item.user_id
         redirect_to action: :index
+     elsif @item.order.present?
+      redirect_to root_path
      end
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -3,7 +3,7 @@ class OrdersController < ApplicationController
 
   def index
       @item = Item.find(params[:item_id])
-    if current_user.id != @item.user_id
+    if current_user.id != @item.user_id  && @item.order.blank?
       @order_address = OrderAddress.new
     else
       redirect_to root_path  
@@ -14,6 +14,7 @@ class OrdersController < ApplicationController
     @order_address = OrderAddress.new(order_params)
     @item = Item.find(params[:item_id])
     if @order_address.valid?
+      pay_item
       @order_address.save
       redirect_to root_path
     else
@@ -24,6 +25,15 @@ class OrdersController < ApplicationController
     private
 
     def order_params
-      params.require(:order_address).permit(:post_code, :prefecture_id, :city, :street_number, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id])
+      params.require(:order_address).permit(:post_code, :prefecture_id, :city, :street_number, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+    end
+
+    def pay_item
+      Payjp.api_key = ENV["PAYJP_SECRET_KEY"]
+      Payjp::Charge.create(
+        amount: @item.price,  
+        card: order_params[:token],    
+        currency: 'jpy'                 
+      )
     end
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,8 +1,8 @@
 class OrdersController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_item, only: [:index, :create]
 
   def index
-      @item = Item.find(params[:item_id])
     if current_user.id != @item.user_id  && @item.order.blank?
       @order_address = OrderAddress.new
     else
@@ -12,7 +12,6 @@ class OrdersController < ApplicationController
    
   def create
     @order_address = OrderAddress.new(order_params)
-    @item = Item.find(params[:item_id])
     if @order_address.valid?
       pay_item
       @order_address.save
@@ -26,6 +25,10 @@ class OrdersController < ApplicationController
 
     def order_params
       params.require(:order_address).permit(:post_code, :prefecture_id, :city, :street_number, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id], token: params[:token])
+    end
+
+    def set_item
+      @item = Item.find(params[:item_id])
     end
 
     def pay_item

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -1,0 +1,29 @@
+class OrdersController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+      @item = Item.find(params[:item_id])
+    if current_user.id != @item.user_id
+      @order_address = OrderAddress.new
+    else
+      redirect_to root_path  
+    end  
+  end
+   
+  def create
+    @order_address = OrderAddress.new(order_params)
+    @item = Item.find(params[:item_id])
+    if @order_address.valid?
+      @order_address.save
+      redirect_to root_path
+    else
+      render :index
+    end 
+  end
+
+    private
+
+    def order_params
+      params.require(:order_address).permit(:post_code, :prefecture_id, :city, :street_number, :building, :phone_number).merge(user_id: current_user.id, item_id: params[:item_id])
+    end
+end

--- a/app/helpers/addresses_helper.rb
+++ b/app/helpers/addresses_helper.rb
@@ -1,0 +1,2 @@
+module AddressesHelper
+end

--- a/app/helpers/orders_helper.rb
+++ b/app/helpers/orders_helper.rb
@@ -1,0 +1,2 @@
+module OrdersHelper
+end

--- a/app/javascript/card.js
+++ b/app/javascript/card.js
@@ -1,0 +1,35 @@
+const pay = () => {
+  Payjp.setPublicKey(process.env.PAYJP_PUBLIC_KEY);
+  const submit = document.getElementById("button");
+  submit.addEventListener("click", (e) => {
+    e.preventDefault();
+
+    const formResult = document.getElementById("charge-form");
+    const formData = new FormData(formResult);
+
+    const card = {
+      number: formData.get("order_address[number]"),
+      cvc: formData.get("order_address[cvc]"),
+      exp_month: formData.get("order_address[exp_month]"),
+      exp_year: `20${formData.get("order_address[exp_year]")}`,
+    };
+
+    Payjp.createToken(card, (status, response) => {
+      if (status == 200) {
+        const token = response.id;
+        const renderDom = document.getElementById("charge-form");
+        const tokenObj = `<input value=${token} name='token' type="hidden"> `;
+        renderDom.insertAdjacentHTML("beforeend", tokenObj);
+      }
+
+      document.getElementById("card-number").removeAttribute("name");
+      document.getElementById("card-cvc").removeAttribute("name");
+      document.getElementById("card-exp-month").removeAttribute("name");
+      document.getElementById("card-exp-year").removeAttribute("name");
+
+      document.getElementById("charge-form").submit();
+    });
+  });
+};
+
+window.addEventListener("load", pay);

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -7,6 +7,7 @@ require("@rails/ujs").start()
 require("@rails/activestorage").start()
 require("channels")
 require("../item_price")
+require("../card")
 
 
 // Uncomment to copy all static images under ../images to the output folder and reference

--- a/app/models/address.rb
+++ b/app/models/address.rb
@@ -1,0 +1,5 @@
+class Address < ApplicationRecord
+
+  belongs_to :order
+
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,6 +7,7 @@ class Item < ApplicationRecord
   belongs_to :scheduled_day
 
   belongs_to :user
+  has_one :order
   has_one_attached :image
 
   validates :image, presence: true

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -1,0 +1,7 @@
+class Order < ApplicationRecord
+
+  belongs_to :user
+  belongs_to :item
+  has_one :address
+
+end

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,6 +1,6 @@
 class OrderAddress
   include ActiveModel::Model
-  attr_accessor :post_code, :prefecture_id, :city, :street_number, :building, :phone_number, :order_id, :user_id, :item_id
+  attr_accessor :post_code, :prefecture_id, :city, :street_number, :building, :phone_number, :order_id, :user_id, :item_id, :token
 
   with_options presence: true do
     validates :post_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
@@ -9,6 +9,7 @@ class OrderAddress
     validates :phone_number, format: {with: /\A\d{10,11}\z/, message: "is invalid"}
     validates :item_id
     validates :user_id
+    validates :token
   end
     validates :prefecture_id, numericality: {other_than: 1, message: "can't be blank"}
 

--- a/app/models/order_address.rb
+++ b/app/models/order_address.rb
@@ -1,0 +1,19 @@
+class OrderAddress
+  include ActiveModel::Model
+  attr_accessor :post_code, :prefecture_id, :city, :street_number, :building, :phone_number, :order_id, :user_id, :item_id
+
+  with_options presence: true do
+    validates :post_code, format: {with: /\A[0-9]{3}-[0-9]{4}\z/, message: "is invalid. Include hyphen(-)"}
+    validates :city
+    validates :street_number
+    validates :phone_number, format: {with: /\A\d{10,11}\z/, message: "is invalid"}
+    validates :item_id
+    validates :user_id
+  end
+    validates :prefecture_id, numericality: {other_than: 1, message: "can't be blank"}
+
+  def save
+    order = Order.create(user_id: user_id, item_id: item_id)
+    Address.create(post_code: post_code, prefecture_id: prefecture_id, city: city, street_number: street_number, building: building, phone_number: phone_number, order_id: order.id)
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,7 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   
   has_many :items  
+  has_many :orders
 
   validates :nickname, presence: true
   validates :password, format: { with: /\A(?=.*?[a-z])(?=.*?[\d])[a-z\d]+\z/i }

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -133,11 +133,11 @@
           <%= link_to item_path(item.id) do %>
             <div class='item-img-content'>
               <%= image_tag item.image, class: "item-img" %>
-              <%# 商品が売れていればsold outを表示しましょう %>
-              <div class='sold-out'>
-                <span>Sold Out!!</span>
-              </div>
-              <%# //商品が売れていればsold outを表示しましょう %>
+              <% if item.order.present? %>
+                <div class='sold-out'>
+                  <span>Sold Out!!</span>
+                </div>
+              <%end%>
             </div>
             <div class='item-info'>
               <h3 class='item-name'>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <%# 商品が売れている場合は、sold outを表示しましょう %>
-      <div class="sold-out">
-        <span>Sold Out!!</span>
-      </div>
-      <%# //商品が売れている場合は、sold outを表示しましょう %>
+      <% if @item.order.present? %>
+        <div class="sold-out">
+          <span>Sold Out!!</span>
+        </div>
+      <%end%>
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,14 +23,12 @@
       </span>
     </div>
 
-  <% if user_signed_in? && current_user.id == @item.user_id %>
+  <% if user_signed_in? && current_user.id == @item.user_id && @item.order.blank?%>
     <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
-  <% elsif user_signed_in? && current_user.id != @item.user_id %>
-    <%# 商品が売れていない場合はこちらを表示しましょう %>
+  <% elsif user_signed_in? && current_user.id != @item.user_id && @item.order.blank? %>
     <%= link_to "購入画面に進む", item_orders_path(@item.id) ,class:"item-red-btn"%>
-    <%# //商品が売れていない場合はこちらを表示しましょう %>
   <% end %>
 
     <div class="item-explain-box">

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -29,7 +29,7 @@
     <%= link_to "削除", item_path(@item.id), method: :delete, class:"item-destroy" %>
   <% elsif user_signed_in? && current_user.id != @item.user_id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
-    <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
+    <%= link_to "購入画面に進む", item_orders_path(@item.id) ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
   <% end %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,8 +6,8 @@
   <%= csrf_meta_tags %>
   <%= csp_meta_tag %>
   <script type="text/javascript" src="https://js.pay.jp/v1/"></script>
-  <%= stylesheet_link_tag 'application', media: 'all'%>
-  <%= javascript_pack_tag 'application' %>
+    <%= stylesheet_link_tag 'application', media: 'all'  %>
+    <%= javascript_pack_tag 'application' %>
 </head>
 
 <body>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -1,0 +1,130 @@
+<%= render "shared/second-header"%>
+
+<div class='transaction-contents'>
+  <div class='transaction-main'>
+    <h1 class='transaction-title-text'>
+      購入内容の確認
+    </h1>
+    <%# 購入内容の表示 %>
+    <div class='buy-item-info'>
+      <%= image_tag @item.image, class: 'buy-item-img' %>
+      <div class='buy-item-right-content'>
+        <h2 class='buy-item-text'>
+          <%= @item.item_name %>
+        </h2>
+        <div class='buy-item-price'>
+          <p class='item-price-text'>¥<%= @item.price %></p>
+          <p class='item-price-sub-text'><%= @item.fee.name %></p>
+        </div>
+      </div>
+    </div>
+    <%# /購入内容の表示 %>
+
+    <%# 支払額の表示 %>
+    <div class='item-payment'>
+      <h1 class='item-payment-title'>
+        支払金額
+      </h1>
+      <p class='item-payment-price'>
+        ¥<%= @item.price %>
+      </p>
+    </div>
+    <%# /支払額の表示 %>
+
+    <%= form_with model: @order_address, url: item_orders_path(@item.id), id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    <%# カード情報の入力 %>
+    <div class='credit-card-form'>
+      <h1 class='info-input-haedline'>
+        クレジットカード情報入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">カード情報</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
+        <div class='available-card'>
+          <%= image_tag 'card-visa.gif', class: 'card-logo'%>
+          <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
+          <%= image_tag 'card-jcb.gif', class: 'card-logo'%>
+          <%= image_tag 'card-amex.gif', class: 'card-logo'%>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">有効期限</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <div class='input-expiration-date-wrap'>
+          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
+          <p>月</p>
+          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
+          <p>年</p>
+        </div>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">セキュリティコード</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :hoge, class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
+      </div>
+    </div>
+    <%# /カード情報の入力 %>
+    
+    <%# 配送先の入力 %>
+    <div class='shipping-address-form'>
+      <h1 class='info-input-haedline'>
+        配送先入力
+      </h1>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">郵便番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :post_code, class:"input-default", id:"postal-code", placeholder:"例）123-4567", maxlength:"8" %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">都道府県</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.collection_select(:prefecture_id, Prefecture.all, :id, :name, {}, {class:"select-box", id:"prefecture"}) %>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">市区町村</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :city, class:"input-default", id:"city", placeholder:"例）横浜市緑区"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">番地</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :street_number, class:"input-default", id:"addresses", placeholder:"例）青山1-1-1"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">建物名</label>
+          <span class="form-any">任意</span>
+        </div>
+        <%= f.text_field :building, class:"input-default", id:"building", placeholder:"例）柳ビル103"%>
+      </div>
+      <div class="form-group">
+        <div class='form-text-wrap'>
+          <label class="form-text">電話番号</label>
+          <span class="indispensable">必須</span>
+        </div>
+        <%= f.text_field :phone_number, class:"input-default", id:"phone-number", placeholder:"例）09012345678",maxlength:"11"%>
+      </div>
+    </div>
+    <%# /配送先の入力 %>
+    <div class='buy-btn'>
+      <%= f.submit "購入" ,class:"buy-red-btn", id:"button" %>
+    </div>
+    <% end %>
+  </div>
+</div>
+<%= render "shared/second-footer"%>

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -32,6 +32,9 @@
     <%# /支払額の表示 %>
 
     <%= form_with model: @order_address, url: item_orders_path(@item.id), id: 'charge-form', class: 'transaction-form-wrap',local: true do |f| %>
+    
+    <%= render 'shared/error_messages', object: f.object %>
+    
     <%# カード情報の入力 %>
     <div class='credit-card-form'>
       <h1 class='info-input-haedline'>
@@ -42,7 +45,7 @@
           <label class="form-text">カード情報</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
+        <%= f.text_field :number, class:"input-default", id:"card-number", placeholder:"カード番号(半角英数字)", maxlength:"16" %>
         <div class='available-card'>
           <%= image_tag 'card-visa.gif', class: 'card-logo'%>
           <%= image_tag 'card-mastercard.gif', class: 'card-logo'%>
@@ -56,9 +59,9 @@
           <span class="indispensable">必須</span>
         </div>
         <div class='input-expiration-date-wrap'>
-          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
+          <%= f.text_area :exp_month, class:"input-expiration-date", id:"card-exp-month", placeholder:"例)3" %>
           <p>月</p>
-          <%= f.text_area :hoge, class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
+          <%= f.text_area :exp_year, class:"input-expiration-date", id:"card-exp-year", placeholder:"例)23" %>
           <p>年</p>
         </div>
       </div>
@@ -67,7 +70,7 @@
           <label class="form-text">セキュリティコード</label>
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_field :hoge, class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
+        <%= f.text_field :cvc, class:"input-default", id:"card-cvc", placeholder:"カード背面4桁もしくは3桁の番号", maxlength:"4" %>
       </div>
     </div>
     <%# /カード情報の入力 %>

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -45,4 +45,5 @@ Rails.application.configure do
 
   # Raises error for missing translations.
   # config.action_view.raise_on_missing_translations = true
+  config.active_job.queue_adapter = :inline
 end

--- a/config/initializers/webpacker.rb
+++ b/config/initializers/webpacker.rb
@@ -1,0 +1,1 @@
+Webpacker::Compiler.env["PAYJP_PUBLIC_KEY"] = ENV["PAYJP_PUBLIC_KEY"]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,4 +2,5 @@ Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
   resources :items
+  resources :orders, only: [:index, :new, :create]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items
-  resources :orders, only: [:index, :new, :create]
+  resources :items do
+    resources :orders, only: [:index, :create] 
+  end
 end

--- a/db/migrate/20221221092111_create_orders.rb
+++ b/db/migrate/20221221092111_create_orders.rb
@@ -1,0 +1,9 @@
+class CreateOrders < ActiveRecord::Migration[6.0]
+  def change
+    create_table :orders do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :item, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221221092423_create_addresses.rb
+++ b/db/migrate/20221221092423_create_addresses.rb
@@ -1,0 +1,14 @@
+class CreateAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :addresses do |t|
+      t.string :post_code, null: false
+      t.integer :prefecture_id, null: false
+      t.string :city, null: false
+      t.string :street_number, null: false
+      t.string :building, null: false
+      t.integer :phone_number, null: false
+      t.references :order, null: false, foreign_key: true
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221221092423_create_addresses.rb
+++ b/db/migrate/20221221092423_create_addresses.rb
@@ -5,7 +5,7 @@ class CreateAddresses < ActiveRecord::Migration[6.0]
       t.integer :prefecture_id, null: false
       t.string :city, null: false
       t.string :street_number, null: false
-      t.string :building, null: false
+      t.string :building
       t.string :phone_number, null: false
       t.references :order, null: false, foreign_key: true
       t.timestamps

--- a/db/migrate/20221221092423_create_addresses.rb
+++ b/db/migrate/20221221092423_create_addresses.rb
@@ -6,7 +6,7 @@ class CreateAddresses < ActiveRecord::Migration[6.0]
       t.string :city, null: false
       t.string :street_number, null: false
       t.string :building, null: false
-      t.integer :phone_number, null: false
+      t.string :phone_number, null: false
       t.references :order, null: false, foreign_key: true
       t.timestamps
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2022_12_21_092423) do
     t.string "city", null: false
     t.string "street_number", null: false
     t.string "building", null: false
-    t.integer "phone_number", null: false
+    t.string "phone_number", null: false
     t.bigint "order_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_19_014015) do
+ActiveRecord::Schema.define(version: 2022_12_21_092423) do
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -33,6 +33,19 @@ ActiveRecord::Schema.define(version: 2022_12_19_014015) do
     t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
   end
 
+  create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "post_code", null: false
+    t.integer "prefecture_id", null: false
+    t.string "city", null: false
+    t.string "street_number", null: false
+    t.string "building", null: false
+    t.integer "phone_number", null: false
+    t.bigint "order_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["order_id"], name: "index_addresses_on_order_id"
+  end
+
   create_table "items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "item_name", null: false
     t.text "item_text", null: false
@@ -46,6 +59,15 @@ ActiveRecord::Schema.define(version: 2022_12_19_014015) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["user_id"], name: "index_items_on_user_id"
+  end
+
+  create_table "orders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["item_id"], name: "index_orders_on_item_id"
+    t.index ["user_id"], name: "index_orders_on_user_id"
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -67,5 +89,8 @@ ActiveRecord::Schema.define(version: 2022_12_19_014015) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "addresses", "orders"
   add_foreign_key "items", "users"
+  add_foreign_key "orders", "items"
+  add_foreign_key "orders", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -38,7 +38,7 @@ ActiveRecord::Schema.define(version: 2022_12_21_092423) do
     t.integer "prefecture_id", null: false
     t.string "city", null: false
     t.string "street_number", null: false
-    t.string "building", null: false
+    t.string "building"
     t.string "phone_number", null: false
     t.bigint "order_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/addresses.rb
+++ b/spec/factories/addresses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :address do
+    
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :order_address do
+    post_code { '123-4567' }
+    prefecture_id { 2 }
+    city { '船橋市緑区' }
+    street_number { '1-1' }
+    building { '東京ハイツ' }
+    phone_number { 1234567890 }
+  end
+end

--- a/spec/factories/order_addresses.rb
+++ b/spec/factories/order_addresses.rb
@@ -6,5 +6,6 @@ FactoryBot.define do
     street_number { '1-1' }
     building { '東京ハイツ' }
     phone_number { 1234567890 }
+    token {"tok_abcdefghijk00000000000000000"}
   end
 end

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :order do
+    
+  end
+end

--- a/spec/helpers/addresses_helper_spec.rb
+++ b/spec/helpers/addresses_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the AddressesHelper. For example:
+#
+# describe AddressesHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe AddressesHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/helpers/orders_helper_spec.rb
+++ b/spec/helpers/orders_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the OrdersHelper. For example:
+#
+# describe OrdersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe OrdersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/address_spec.rb
+++ b/spec/models/address_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Address, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Item, type: :model do
   describe '商品出品' do
     context '正常に登録できる時' do
       it '全ての条件が揃った場合に商品登録ができる' do
-        expect(@item).to be_valid
+        expect(@item).to be_valid 
       end
     end
 

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe OrderAddress, type: :model do
+  describe '購入情報の保存' do
+    before do
+      @user = FactoryBot.create(:user)
+      @item = FactoryBot.create(:item)
+      @order_address = FactoryBot.build(:order_address, item_id: @item.id, user_id: @user.id)
+    end
+
+    context '内容に問題ない場合' do
+      it 'すべての値が正しく入力されていれば保存できること' do
+        expect(@order_address).to be_valid
+      end
+      it 'bulidingは空でも保存できること' do
+        @order_address.building = ''
+        expect(@order_address).to be_valid
+      end
+    end
+    context '内容に問題がある場合' do
+
+      it 'post_codeが空だと保存できないこと' do
+        @order_address.post_code = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "Post code can't be blank"
+      end
+      it 'post_codeが半角のハイフンを含んだ正しい形式でないと保存できないこと' do
+        @order_address.post_code = '1234567'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "Post code is invalid. Include hyphen(-)"
+      end
+      it 'prefecture_idを選択していないと保存できないこと' do
+        @order_address.prefecture_id = 1
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "Prefecture can't be blank"
+      end
+      it 'cityが空だと保存できないこと' do
+        @order_address.city = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "City can't be blank"
+      end
+      it 'street_numberが空だと保存できないこと' do
+        @order_address.street_number = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "Street number can't be blank"
+      end
+      it 'phone_numberが空だと保存できないこと' do
+        @order_address.phone_number = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "Phone number can't be blank"
+      end
+      it 'phone_numberが11桁以上だと保存できないこと' do
+        @order_address.phone_number = '111111111111'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "Phone number is invalid"
+      end
+      it 'phone_numberが10桁以下だと保存できないこと' do
+        @order_address.phone_number = '111111'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "Phone number is invalid"
+      end
+      it 'phone_numberが半角数値以外だと保存できないこと' do
+        @order_address.phone_number = 'アイウエオ'
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "Phone number is invalid"
+      end
+      it 'item_idが空だと保存できないこと' do
+        @order_address.item_id = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "Item can't be blank"
+      end
+      it 'user_idが空だと保存できないこと' do
+        @order_address.user_id = ''
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include "User can't be blank"
+      end
+    end
+  end
+end

--- a/spec/models/order_address_spec.rb
+++ b/spec/models/order_address_spec.rb
@@ -74,6 +74,11 @@ RSpec.describe OrderAddress, type: :model do
         @order_address.valid?
         expect(@order_address.errors.full_messages).to include "User can't be blank"
       end
+      it "tokenが空では登録できないこと" do
+        @order_address.token = nil
+        @order_address.valid?
+        expect(@order_address.errors.full_messages).to include("Token can't be blank")
+      end
     end
   end
 end

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Order, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/addresses_request_spec.rb
+++ b/spec/requests/addresses_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Addresses", type: :request do
+
+end

--- a/spec/requests/orders_request_spec.rb
+++ b/spec/requests/orders_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Orders", type: :request do
+
+end


### PR DESCRIPTION
# What
商品購入画面の作成

# Why
商品購入機能の実装

購入実装に伴い、以下も実装、確認しています。
★商品一覧表示機能　#6：「 売却済みの商品は、画像上に「sold out」の文字が表示されること。」
★商品詳細表示機能 #7：「ログイン状態且つ、自身が出品した販売中商品の場合にのみ、「商品の編集」「削除」ボタンが表示されること。」「ログイン状態且つ、自身が出品していない販売中商品の場合にのみ、「購入画面に進む」ボタンが表示されること。」「ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。」「ログアウト状態の場合は、商品の販売状況に関わらず、「商品の編集」「削除」「購入画面に進む」ボタンが表示されないこと。」
★商品情報編集機能　#8 ：「 ログイン状態の場合でも、自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移すること。」

以下、動画です。

必要な情報を適切に入力して「購入」ボタンを押すと、商品の購入ができる動画
https://gyazo.com/111f36b1951d0fa52ed1314b7800fb12
※PAY JPと DBでの更新ができている
https://gyazo.com/3608f76f847770f6b17b7bd7b8cf1f3f
https://gyazo.com/ace635850f8b4c2cdce1cc683c288c27
 入力に問題がある状態で「購入」ボタンが押された場合、情報は受け入れられず、購入ページでエラーメッセージが表示される動画
https://gyazo.com/fdd6d0eb61293f243635f51b7a7144b3
 ログイン状態の場合でも、URLを直接入力して自身が出品していない売却済み商品の商品購入ページへ遷移しようとすると、トップページに遷移する動画
https://gyazo.com/034aa8be3e389d8ffc52b764afd121ee
 ログイン状態の場合でも、URLを直接入力して自身が出品した商品の商品購入ページに遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/11eaeb919db3dff5628bf4336bbb9b97
 ログアウト状態の場合は、URLを直接入力して商品購入ページに遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/0ae1d383e67559ef921f8ba12431edb1
 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品一覧機能実装時に未実装であった場合）
https://gyazo.com/c23de7eda91dce51e722541554c03ddf
 売却済みの商品は、画像上に「sold out」の文字が表示される動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/1d9af5b3d1749b13ceea8bac7d0c9b8b
 ログイン状態の場合でも、売却済みの商品には、「商品の編集」「削除」「購入画面に進む」ボタンが表示されない動画（商品詳細機能実装時に未実装であった場合）
https://gyazo.com/ab6c61a81661f2312b810a6ad497bc8c
 ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（商品情報編集機能実装時に未実装であった場合）
https://gyazo.com/e65e089fd8ac73f7e7414c9109256358
 テスト結果の画像
https://gyazo.com/ea6d26e68d48e462d451a73efebf1ed4

